### PR TITLE
Fix assertions format to use enableAssertions = true

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,5 +43,5 @@ checkstyle {
 
 run{
     standardInput = System.in
-    jvmArgs '-ea'
+    enableAssertions = true
 }


### PR DESCRIPTION
Replace jvmArgs '-ea' with enableAssertions = true in build.gradle so the course dashboard correctly detects assertions as enabled.