### PR TITLE
Update help descriptions for interview and rejected commands

### DIFF
--- a/src/main/java/seedu/goldencompass/command/AddInterviewCommand.java
+++ b/src/main/java/seedu/goldencompass/command/AddInterviewCommand.java
@@ -24,10 +24,11 @@ public class AddInterviewCommand extends Command {
     private static final String FLAG_DATE = "/d";
     private static final String COMMAND_DESCRIPTION =
             "Adds an interview linked to an existing internship.\n"
-            + "Format: add-interview INDEX /d DATE";
+            + "Format: add-interview INDEX /d DATE\n"
+            + "Example: add-interview 2 /d 2025-06-15 10:00";
     private static final String FLAG_DESCRIPTION =
             "Flags:\n"
-            + "/d - specifies the interview date (yyyy-MM-dd).";
+            + "/d - specifies the interview date and time (yyyy-MM-dd HH:mm).";
 
     private final InternshipList internshipList;
     private final InterviewList interviewList;

--- a/src/main/java/seedu/goldencompass/command/ClearRejectedCommand.java
+++ b/src/main/java/seedu/goldencompass/command/ClearRejectedCommand.java
@@ -45,11 +45,12 @@ public class ClearRejectedCommand extends Command {
 
     @Override
     protected String getCommandDescription() {
-        return "";
+        return "Removes all internships marked as rejected from the list.\n"
+                + "Format: clear-rejected";
     }
 
     @Override
     protected String getFlagDescription() {
-        return "";
+        return "This command does not take any flags.";
     }
 }

--- a/src/main/java/seedu/goldencompass/command/SearchInterviewCommand.java
+++ b/src/main/java/seedu/goldencompass/command/SearchInterviewCommand.java
@@ -41,16 +41,6 @@ public class SearchInterviewCommand extends Command {
     }
 
     @Override
-    public String getCommandDescription() {
-        return "";
-    }
-
-    @Override
-    public String getFlagDescription() {
-        return "";
-    }
-
-    @Override
     public void execute() throws GoldenCompassException {
         assert parser != null : "Parser should not be null";
         assert interviewList != null : "InterviewList should not be null";
@@ -101,5 +91,15 @@ public class SearchInterviewCommand extends Command {
             return null;
         }
         return params.get(0).trim();
+    }
+
+    @Override
+    protected String getCommandDescription() {
+        return COMMAND_DESCRIPTION;
+    }
+
+    @Override
+    protected String getFlagDescription() {
+        return FLAG_DESCRIPTION;
     }
 }

--- a/src/main/java/seedu/goldencompass/command/SetInterviewDeadlineCommand.java
+++ b/src/main/java/seedu/goldencompass/command/SetInterviewDeadlineCommand.java
@@ -22,11 +22,12 @@ public class SetInterviewDeadlineCommand extends Command {
 
     private static final String FLAG_DATE = "/d";
     private static final String COMMAND_DESCRIPTION =
-            "Sets the deadline date of an interview.\n"
-            + "Format: update-date INDEX /d DATE";
+            "Sets the deadline date and time of an interview.\n"
+            + "Format: update-date INDEX /d DATE\n"
+            + "Example: update-date 1 /d 2025-04-15 14:00";
     private static final String FLAG_DESCRIPTION =
             "Flags:\n"
-            + "/d - specifies the date (yyyy-MM-dd).";
+            + "/d - specifies the date and time (yyyy-MM-dd HH:mm).";
 
     private final InterviewList interviewList;
 
@@ -40,16 +41,6 @@ public class SetInterviewDeadlineCommand extends Command {
     public SetInterviewDeadlineCommand(Parser parser, InterviewList interviewList) {
         super(parser);
         this.interviewList = interviewList;
-    }
-
-    @Override
-    public String getCommandDescription() {
-        return "";
-    }
-
-    @Override
-    public String getFlagDescription() {
-        return "";
     }
 
     /**
@@ -116,5 +107,15 @@ public class SetInterviewDeadlineCommand extends Command {
         interview.setDate(date);
 
         ui.print("Deadline set for interview " + index + ": " + date);
+    }
+
+    @Override
+    protected String getCommandDescription() {
+        return COMMAND_DESCRIPTION;
+    }
+
+    @Override
+    protected String getFlagDescription() {
+        return FLAG_DESCRIPTION;
     }
 }


### PR DESCRIPTION
Fix getCommandDescription/getFlagDescription to return actual help text instead of empty strings. Change access modifier to protected to match base class. Update date format to yyyy-MM-dd HH:mm in help messages.