### PR TITLE
Fix logger output showing question marks on non-English locales

### DIFF
--- a/src/main/java/seedu/goldencompass/GoldenCompass.java
+++ b/src/main/java/seedu/goldencompass/GoldenCompass.java
@@ -51,11 +51,10 @@ public class GoldenCompass {
     public static void main(String[] args) throws IOException, GoldenCompassException {
 
         Logger rootLogger = Logger.getLogger("");
-        rootLogger.setLevel(Level.WARNING);
+        rootLogger.setLevel(Level.OFF);
 
         for (Handler h : rootLogger.getHandlers()) {
-            h.setLevel(Level.WARNING);
-            h.setEncoding("UTF-8");
+            h.setLevel(Level.OFF);
         }
         new GoldenCompass().run();
 


### PR DESCRIPTION
Set console handler encoding to UTF-8 so log timestamps render correctly on systems with CJK locales.