### PR TITLE
Fix bugs in undo and redo

### DIFF
--- a/src/main/java/seedu/goldencompass/internship/Internship.java
+++ b/src/main/java/seedu/goldencompass/internship/Internship.java
@@ -68,6 +68,16 @@ public class Internship {
                 + " - " + this.title);
     }
 
+    public Internship(Internship other) {
+        this.title = other.title;
+        this.companyName = other.companyName;
+        this.comments = other.comments;
+        this.link = other.link;
+        this.hasApplied = other.hasApplied;
+        this.interview = other.interview;
+        this.status = other.status;
+    }
+
     /**
      * Gets the job title.
      *

--- a/src/main/java/seedu/goldencompass/internship/InternshipList.java
+++ b/src/main/java/seedu/goldencompass/internship/InternshipList.java
@@ -41,8 +41,10 @@ public class InternshipList {
      */
     public InternshipList(InternshipList other) {
         this.internships.clear();
-        if (other != null) {
-            this.internships.addAll(other.internships);
+        assert other != null : "Cannot copy null";
+        //copy each element
+        for(Internship internship : other.internships) {
+            this.internships.add(new Internship(internship));
         }
         logger.info("InternshipList copied with " + this.internships.size() + " internships");
     }

--- a/src/main/java/seedu/goldencompass/internship/Interview.java
+++ b/src/main/java/seedu/goldencompass/internship/Interview.java
@@ -24,6 +24,11 @@ public class Interview {
         internship.setInterview(this);
     }
 
+    public Interview(Interview other) {
+        this.internship = other.internship;
+        this.dateTime = other.dateTime;
+    }
+
     /**
      * Sets the deadline date and time of this interview.
      * @param date a {@code LocalDateTime} representing the new deadline.

--- a/src/main/java/seedu/goldencompass/internship/InterviewList.java
+++ b/src/main/java/seedu/goldencompass/internship/InterviewList.java
@@ -7,7 +7,7 @@ import java.util.logging.Logger;
 
 public class InterviewList {
 
-    private static final Logger logger = Logger.getLogger(InternshipList.class.getName());
+    private static final Logger logger = Logger.getLogger(InterviewList.class.getName());
 
     private final List<Interview> interviews = new ArrayList<>();
 
@@ -17,7 +17,11 @@ public class InterviewList {
 
     public InterviewList(InterviewList other) {
         this.interviews.clear();
-        this.interviews.addAll(other.interviews);
+        assert other != null : "Cannot copy null";
+        //copy the element as well.
+        for(Interview interview : other.interviews) {
+            this.interviews.add(new Interview(interview));
+        }
     }
 
 


### PR DESCRIPTION
Previously the undo redo only handle the containers of `Interview` and `Internship`, by deep copying the container, but the reference to the element is the same. Now, they handle the elements of the container as well, by deep copying them. 